### PR TITLE
临时跳过泛型函数

### DIFF
--- a/inspect/rewrite.go
+++ b/inspect/rewrite.go
@@ -213,6 +213,12 @@ func rewriteFile(pkg *packages.Package, pkgPath string, fset *token.FileSet, f *
 			}
 			funcName := n.Name.Name
 
+			// cannot mock functions with type params now
+			// TODO add support for generic functions
+			if n.Type.TypeParams != nil {
+				return true
+			}
+
 			// package level init function cannot be mocked
 			// because go allows init be defined multiple times in a file,and across files
 			if ownerType == "" && funcName == "init" {


### PR DESCRIPTION
当前不支持 mock 泛型函数，如果项目中有用到泛型会 panic。

长期来看还是要支持泛型的。在添加该功能之前先忽略泛型函数。